### PR TITLE
Implement SMB2_FILE_DISPOSITION_INFO in SMB3.rmdir() method.

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1460,7 +1460,14 @@ class SMB3:
 
         fileId = None
         try:
-            fileId = self.create(treeId, pathName, DELETE, FILE_SHARE_DELETE, FILE_DIRECTORY_FILE | FILE_DELETE_ON_CLOSE, FILE_OPEN, 0)
+            fileId = self.create(treeId, pathName, desiredAccess=DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                                 shareMode=FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                 creationOptions=FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+                                 creationDisposition=FILE_OPEN, fileAttributes=0)
+            from impacket import smb
+            delete_req = smb.SMBSetFileDispositionInfo()
+            delete_req['DeletePending'] = True
+            self.setInfo(treeId, fileId, inputBlob=delete_req, fileInfoClass=SMB2_FILE_DISPOSITION_INFO)
         finally:
             if fileId is not None:
                 self.close(treeId, fileId)


### PR DESCRIPTION
Right now SMB3.rmdir() does not throw error STATUS_DIRECTORY_NOT_EMPTY when directory to be deleted is not empty, Instead it silently continues and returns success.

Note that if the DELETE_ON_CLOSE flag is specified on a directory with child files or directories, the create operation will succeed, but the delete on close flag will be silently ignored when processing the cleanup IRP and the directory will not be deleted. 
[MS-FSCC] 2.4.11 http://go.microsoft.com/fwlink/?LinkId=140636